### PR TITLE
Replacing the "TransactionSupport" parameter of @Aspect by an @Step method annotation.

### DIFF
--- a/k3-al/fr.inria.diverse.k3.al.annotationprocessor/src/main/java/fr/inria/diverse/k3/al/annotationprocessor/Helper.xtend
+++ b/k3-al/fr.inria.diverse.k3.al.annotationprocessor/src/main/java/fr/inria/diverse/k3/al/annotationprocessor/Helper.xtend
@@ -189,17 +189,6 @@ abstract class Helper {
 		}catch(NullPointerException ex){ return null }
 	}
 
-
-	static def TransactionSupport getAnnotationTransactionSupport(TypeDeclaration cl) {
-		if(cl===null || cl.annotations===null) return TransactionSupport.None;
-		try{
-			val annot = cl.annotations.findFirst[getClassValue(annotationName) !== null]
-			if(annot===null) return TransactionSupport.None
-			return TransactionSupport.valueOf(annot.getEnumValue(annotationTransactionSupportName).simpleName)
-		}catch(NullPointerException ex){ return TransactionSupport.None }
-	}
-
-
 	/** Computes the name of the class to aspectize identified by the annotation 'aspect'. */
 	static def String getAspectedClassName(TypeDeclaration clazz) {
 		val type = getAnnotationAspectType(clazz)

--- a/k3-al/fr.inria.diverse.k3.al.annotationprocessor/src/main/java/fr/inria/diverse/k3/al/annotationprocessor/stepmanager/IStepManager.xtend
+++ b/k3-al/fr.inria.diverse.k3.al.annotationprocessor/src/main/java/fr/inria/diverse/k3/al/annotationprocessor/stepmanager/IStepManager.xtend
@@ -1,0 +1,9 @@
+package fr.inria.diverse.k3.al.annotationprocessor.stepmanager
+
+interface IStepManager {
+
+	def Object execute(Object caller, StepCommand command, String methodName);
+	
+	def boolean canHandle(Object caller);
+
+}

--- a/k3-al/fr.inria.diverse.k3.al.annotationprocessor/src/main/java/fr/inria/diverse/k3/al/annotationprocessor/stepmanager/IStepManager.xtend
+++ b/k3-al/fr.inria.diverse.k3.al.annotationprocessor/src/main/java/fr/inria/diverse/k3/al/annotationprocessor/stepmanager/IStepManager.xtend
@@ -2,7 +2,7 @@ package fr.inria.diverse.k3.al.annotationprocessor.stepmanager
 
 interface IStepManager {
 
-	def Object execute(Object caller, StepCommand command, String methodName);
+	def void executeStep(Object caller, StepCommand command, String methodName);
 	
 	def boolean canHandle(Object caller);
 

--- a/k3-al/fr.inria.diverse.k3.al.annotationprocessor/src/main/java/fr/inria/diverse/k3/al/annotationprocessor/stepmanager/README.md
+++ b/k3-al/fr.inria.diverse.k3.al.annotationprocessor/src/main/java/fr/inria/diverse/k3/al/annotationprocessor/stepmanager/README.md
@@ -1,0 +1,49 @@
+# Using the `@Step` annotation
+
+The `@Step` annotation can be used to delegate the execution of a K3AL operation to some other external component.
+More precisely, the generated code will create a `StepCommand` object whose `execute` method contains all the code, an pass it to this component.
+
+# Implementing the`IStepManager` interface
+
+Such external component must implements the `IStepManager` interface, which consists of two operations:
+
+- `execute(Object caller, StepCommand command, String methodName)`, to handle the execution of the `command` knowing both which object was the `caller` and
+what was the `methodName` called;
+- `canHandle(Object caller)`, to tell whether or not the manager can handle the execution of an operation called by this object.
+
+Example of a `IStepManager` implementation that only manages instances of classes whose names begin with `Toto`, and that prints messages when steps are executed:
+~~~~
+package my.pkg.toto;
+
+import fr.inria.diverse.k3.al.annotationprocessor.stepmanager.IStepManager;
+import fr.inria.diverse.k3.al.annotationprocessor.stepmanager.StepCommand;
+
+public class MyStepManager implements IStepManager {
+
+	@Override
+	public void executeStep(Object caller, StepCommand command, String methodName) {
+		System.out.println("Starting " + methodName + " called by " + caller);
+		command.execute();
+		System.out.println("Ending " + methodName + " called by " + caller);
+	}
+
+	@Override
+	public boolean canHandle(Object caller) {
+		return caller.getClass().getSimpleName().startsWith("Toto");
+	}
+
+}
+~~~~
+
+# Using `StepManagerRegistry` to register managers
+
+`IStepManager` implementations must be registered at runtime using the `StepManagerRegistry` singleton. For instance:
+
+~~~~
+StepManagerRegistry.getInstance().registerManager(new MyStepManager());
+~~~~
+
+# GEMOC case
+
+A more complete example can be found in the GEMOC project, with the class `PlainK3ExecutionEngine` that handles the execution of `@Step` methods using EMF Transaction,
+while making sure that there are no compound transactions (ie starting a transaction within a transaction).

--- a/k3-al/fr.inria.diverse.k3.al.annotationprocessor/src/main/java/fr/inria/diverse/k3/al/annotationprocessor/stepmanager/StepCommand.xtend
+++ b/k3-al/fr.inria.diverse.k3.al.annotationprocessor/src/main/java/fr/inria/diverse/k3/al/annotationprocessor/stepmanager/StepCommand.xtend
@@ -1,0 +1,17 @@
+package fr.inria.diverse.k3.al.annotationprocessor.stepmanager
+
+abstract class StepCommand {
+
+	private java.util.List<Object> result = new java.util.ArrayList<Object>();
+
+	public def void execute() ;
+	
+	protected def boolean addToResult(Object o) {
+		return result.add(o);
+	}
+
+	public def java.util.Collection<?> getResult() {
+		return result.immutableCopy
+	}
+
+}

--- a/k3-al/fr.inria.diverse.k3.al.annotationprocessor/src/main/java/fr/inria/diverse/k3/al/annotationprocessor/stepmanager/StepManagerRegistry.xtend
+++ b/k3-al/fr.inria.diverse.k3.al.annotationprocessor/src/main/java/fr/inria/diverse/k3/al/annotationprocessor/stepmanager/StepManagerRegistry.xtend
@@ -1,0 +1,38 @@
+package fr.inria.diverse.k3.al.annotationprocessor.stepmanager
+
+import java.util.Set
+import java.util.HashSet
+
+class StepManagerRegistry {
+
+	private static var StepManagerRegistry instance;
+
+	private Set<IStepManager> registeredManagers;
+	
+	private new() {
+		this.registeredManagers = new HashSet<IStepManager>();
+	}
+
+	public static def StepManagerRegistry getInstance() {
+		if(instance == null)
+			instance = new StepManagerRegistry()
+		return instance
+	}
+
+	public def void registerManager(IStepManager manager) {
+		if(manager != null)
+			registeredManagers.add(manager)
+	}
+	
+	public def void unregisterManager(IStepManager manager) {
+		if(manager != null)
+			registeredManagers.remove(manager)
+	}
+	
+	
+
+	public def IStepManager findStepManager(Object caller) {
+		return registeredManagers.findFirst[m|m.canHandle(caller)];
+	}
+
+}


### PR DESCRIPTION
Replacing the `TransactionSupport` parameter of `@Aspect` by an `@Step` method annotation.

The code is a bit simpler: no more `enum` to handle multiple cases, a `boolean` is used to tell whether `@Step` is there or not.

Also the generated code is now independent from EMF/GEMOC, using a registry singleton that external projects must use.

See commits comments and/or the README for more details :)