### PR TITLE
Try to give a more meaningful error message in case of time out

### DIFF
--- a/k3.eclipse/fr.inria.diverse.k3.al.annotationprocessor.plugin/src/fr/inria/diverse/k3/al/annotationprocessor/Aspect.xtend
+++ b/k3.eclipse/fr.inria.diverse.k3.al.annotationprocessor.plugin/src/fr/inria/diverse/k3/al/annotationprocessor/Aspect.xtend
@@ -881,7 +881,8 @@ if («SELF_VAR_NAME» instanceof «Helper::getAspectedClassName(dt)»){
 						// or may be currently being written
 						if(!waitForFileContent(superclassjavafile, context)){
 							// timeout occured
-							println(this+" timeout occurred while waiting for "+superclassjavafile)
+							println('''[«this»] Timeout occured while processing «classDecl.qualifiedName».«m.simpleName». Aspect processor is waiting for «superclassjavafile» ''')
+//							println(this+" timeout occurred while waiting for "+superclassjavafile)
 						} else synchronized(lock){						
 						 	
 							val hasReturn = m.returnType.name != "void"

--- a/k3.eclipse/fr.inria.diverse.k3.al.annotationprocessor.plugin/src/fr/inria/diverse/k3/al/annotationprocessor/Aspect.xtend
+++ b/k3.eclipse/fr.inria.diverse.k3.al.annotationprocessor.plugin/src/fr/inria/diverse/k3/al/annotationprocessor/Aspect.xtend
@@ -882,7 +882,6 @@ if («SELF_VAR_NAME» instanceof «Helper::getAspectedClassName(dt)»){
 						if(!waitForFileContent(superclassjavafile, context)){
 							// timeout occured
 							println('''[«this»] Timeout occured while processing «classDecl.qualifiedName».«m.simpleName». Aspect processor is waiting for «superclassjavafile» ''')
-//							println(this+" timeout occurred while waiting for "+superclassjavafile)
 						} else synchronized(lock){						
 						 	
 							val hasReturn = m.returnType.name != "void"


### PR DESCRIPTION
With the current error message, when a time out occurs, I get:

```
fr.inria.diverse.k3.al.annotationprocessor.AspectProcessor@6eb61734 timeout occurred while waiting for /duc.uscript.execution.interpreter/xtend-gen/duc/uscript/execution/interpreter/modelstate/ValueAspect.java
fr.inria.diverse.k3.al.annotationprocessor.AspectProcessor@24e4cf53 timeout occurred while waiting for /duc.uscript.execution.interpreter/xtend-gen/duc/uscript/execution/interpreter/modelstate/ValueAspect.java
fr.inria.diverse.k3.al.annotationprocessor.AspectProcessor@6eea8a26 timeout occurred while waiting for /duc.uscript.execution.interpreter/xtend-gen/duc/uscript/execution/interpreter/expression/ExpressionAspect.java
fr.inria.diverse.k3.al.annotationprocessor.AspectProcessor@3030fd4b timeout occurred while waiting for /duc.uscript.execution.interpreter/xtend-gen/duc/uscript/execution/interpreter/statement/StatementAspect.java
fr.inria.diverse.k3.al.annotationprocessor.AspectProcessor@54014a35 timeout occurred while waiting for /duc.uscript.execution.interpreter/xtend-gen/duc/uscript/execution/interpreter/expression/ExpressionAspect.java
```

I would like to know for which class the time out occurred. Info. not visible here