### PR TITLE
Make step manager thread-safe

### DIFF
--- a/k3.eclipse/fr.inria.diverse.k3.al.annotationprocessor.plugin/src/fr/inria/diverse/k3/al/annotationprocessor/stepmanager/StepManagerRegistry.xtend
+++ b/k3.eclipse/fr.inria.diverse.k3.al.annotationprocessor.plugin/src/fr/inria/diverse/k3/al/annotationprocessor/stepmanager/StepManagerRegistry.xtend
@@ -12,35 +12,38 @@ package fr.inria.diverse.k3.al.annotationprocessor.stepmanager
 
 import java.util.Set
 import java.util.HashSet
+import java.util.Collections
 
 class StepManagerRegistry {
 
-	private static var StepManagerRegistry instance;
+	static var StepManagerRegistry instance;
 
-	private Set<IStepManager> registeredManagers;
+	Set<IStepManager> registeredManagers;
 
 	private new() {
-		this.registeredManagers = new HashSet<IStepManager>();
+		this.registeredManagers = Collections.synchronizedSet(new HashSet<IStepManager>());
 	}
 
-	public static def StepManagerRegistry getInstance() {
+	static def StepManagerRegistry getInstance() {
 		if (instance === null)
 			instance = new StepManagerRegistry()
 		return instance
 	}
 
-	public def void registerManager(IStepManager manager) {
+	def void registerManager(IStepManager manager) {
 		if (manager !== null)
 			registeredManagers.add(manager)
 	}
 
-	public def void unregisterManager(IStepManager manager) {
+	def void unregisterManager(IStepManager manager) {
 		if (manager !== null)
 			registeredManagers.remove(manager)
 	}
 
-	public def IStepManager findStepManager(Object caller) {
-		return registeredManagers.findFirst[m|m.canHandle(caller)];
+	def IStepManager findStepManager(Object caller) {
+		synchronized (registeredManagers) {
+			return registeredManagers.findFirst[m|m.canHandle(caller)];
+		}
 	}
 
 }


### PR DESCRIPTION
In an experiment where we create lots of GEMOC execution engines, we ended up facing a weird problem with a `ConcurrentModificationException` occurring in the K3 annotation processor code, more precisely in the `StepManagerRegistry` code.

It turns out that when several K3 programs run in parallel, and make use of the `StepManagerRegistry`, they may trigger at the same time both a call to `findStepManager` (which tries to find a step manager), and a call to `(un)registerManager` (which modifies the global/singleton list of global variables). This is most likely what triggers the `ConcurrentModificationException`.

I'm starting this PR to make the small changes required for such a problem to disappear, basically using the Java standard facilities to make an iteration safe. I haven't tested the code yet, but we will re-create the conditions of the experiment soon to see if this is enough for the problem to disappear.