### PR TITLE
Make StepCommand return Optionals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 **target/
 **bin/
 /.project
+.cache
+.repository

--- a/k3.eclipse/fr.inria.diverse.k3.al.annotationprocessor.plugin/src/fr/inria/diverse/k3/al/annotationprocessor/Aspect.xtend
+++ b/k3.eclipse/fr.inria.diverse.k3.al.annotationprocessor.plugin/src/fr/inria/diverse/k3/al/annotationprocessor/Aspect.xtend
@@ -455,7 +455,7 @@ if («SELF_VAR_NAME» instanceof «Helper::getAspectedClassName(dt)»){
 				command.execute();
 			}
 			«IF hasReturn»
-			«resultVar» = command.getResult();
+			«resultVar» = command.getResult().get();
 			«ENDIF»
 		'''
 	}

--- a/k3.eclipse/fr.inria.diverse.k3.al.annotationprocessor.plugin/src/fr/inria/diverse/k3/al/annotationprocessor/stepmanager/StepCommand.xtend
+++ b/k3.eclipse/fr.inria.diverse.k3.al.annotationprocessor.plugin/src/fr/inria/diverse/k3/al/annotationprocessor/stepmanager/StepCommand.xtend
@@ -10,17 +10,19 @@
  *******************************************************************************/
  package fr.inria.diverse.k3.al.annotationprocessor.stepmanager
 
+import java.util.Optional
+
 abstract class StepCommand {
 
-	private Object result
+	private Optional<Object> result = Optional.empty
 
 	public def void execute() ;
 	
 	protected def void addToResult(Object o) {
-		result = o;
+		result = Optional.of(o);
 	}
 
-	public def Object getResult() {
+	public def Optional<Object> getResult() {
 		return result;
 	}
 


### PR DESCRIPTION
**Context:** The `@Step` annotation will result in creating `StepCommand` elements that are sent to an external step manager (in most cases, a GEMOC Studio engine). A `StepCommand` include a way to execute the step, and a way to retrieve the returned value of the step.

**Problem:** there is no way to distinguish these two cases: 
- If the step method is `void` then there is no return value and the `StepCommand` will contain a `null` return value by default.  
- If a step may return an objet, it may return the `null` value.

The consequence is that a StepManager can get confused about whether the operation really returned a `null` value, or did not return a value at all.

**Solution:** This PR makes K3 store the return value of a step as an `Optional`, which remains `empty` by default (and thus when there is no return value). 