### PR TITLE
Fix wrong parameters list in step with only _self

### DIFF
--- a/k3.eclipse/fr.inria.diverse.k3.al.annotationprocessor.plugin/src/fr/inria/diverse/k3/al/annotationprocessor/Aspect.xtend
+++ b/k3.eclipse/fr.inria.diverse.k3.al.annotationprocessor.plugin/src/fr/inria/diverse/k3/al/annotationprocessor/Aspect.xtend
@@ -388,8 +388,8 @@ public class AspectProcessor extends AbstractClassProcessor {
 		var String privcall = '''«dt.newTypeReference.name».«PRIV_PREFIX+m.simpleName»(_self_, «parametersString.replaceFirst(SELF_VAR_NAME,
 							"(" + Helper::getAspectedClassName(dt) + ")"+SELF_VAR_NAME)»)'''
 		if (isStep) {
-			privcall = surroundWithStepCommandExecution(className, m.simpleName, privcall, hasReturn, resultVar,
-				parametersString.substring(parametersString.indexOf(',') + 1))
+			val parametersWithoutSelf = if (parametersString.contains(',')) parametersString.substring(parametersString.indexOf(',') + 1) else "";
+			privcall = surroundWithStepCommandExecution(className, m.simpleName, privcall, hasReturn, resultVar, parametersWithoutSelf)
 		} else if (hasReturn)
 			privcall = '''«resultVar» = «privcall»'''
 		


### PR DESCRIPTION
Currently, K3 is wrongly providing parameters to execution steps. In particular, when there should be no parameters, K3 is still providing a list containing `_self`, which should only be the caller and not the parameter.

The reason for this bug is that the current code relies on a simple split in a comma `,` to remove the `_self` element. However, when there is _only_ a `_self` element, then there is no comma, therefore it is not removed.

This PR fixes this problem.