### PR TITLE
update Github actions

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -33,10 +33,10 @@ jobs:
     #  with:
     #    report_paths: '**/target/surefire-reports/TEST-*.xml'
     - name: Publish Test Results
-      uses: EnricoMi/publish-unit-test-result-action/composite@v1
+      uses: EnricoMi/publish-unit-test-result-action@v2.3.0
       if: always()  # always run even if the previous step fails
       with:
-        files: "**/target/surefire-reports/TEST-*.xml"
+        junit_files: "**/target/surefire-reports/TEST-*.xml"
     #- name: Archive logs 📦
     #  uses: actions/upload-artifact@v3
     #  if: always() # always run even if the previous step fails

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -25,9 +25,7 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Build and Verify ⚒️🧪
-      uses: GabrielBB/xvfb-action@v1.6
-      with:
-         run: mvn -B verify --file pom.xml
+      run: xvfb-run -a mvn -B verify --file pom.xml
     
     #- name: Publish Test Report 🔍
     #  uses: mikepenz/action-junit-report@v3

--- a/k3-al/fr.inria.diverse.k3.al.tests/.gitignore
+++ b/k3-al/fr.inria.diverse.k3.al.tests/.gitignore
@@ -4,3 +4,4 @@
 /META-INF
 /src/main/generated-sources
 /src/test/generated-sources
+*/gen-plantuml/*


### PR DESCRIPTION
1/ The [GabrielBB/xvfb-action](https://github.com/GabrielBB/xvfb-action) that we use for testing is using the deprecated Node 12 base image and appears to be unmaintained. Since the `ubuntu-latest` image now includes `xvfb-run`, we can replace this image  to use `xvfb-run`.

2/ bump EnricoMi/publish-unit-test-result-action to 2.3.0