### PR TITLE
Fix: replace optional by list in step return value

### DIFF
--- a/k3.eclipse/fr.inria.diverse.k3.al.annotationprocessor.plugin/src/fr/inria/diverse/k3/al/annotationprocessor/stepmanager/StepCommand.xtend
+++ b/k3.eclipse/fr.inria.diverse.k3.al.annotationprocessor.plugin/src/fr/inria/diverse/k3/al/annotationprocessor/stepmanager/StepCommand.xtend
@@ -4,25 +4,32 @@
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
  * Contributors:
  *     Inria - initial API and implementation
  *******************************************************************************/
- package fr.inria.diverse.k3.al.annotationprocessor.stepmanager
+package fr.inria.diverse.k3.al.annotationprocessor.stepmanager
 
-import java.util.Optional
+import java.util.Collections
+import java.util.List
 
 abstract class StepCommand {
 
-	private Optional<Object> result = Optional.empty
+	List<Object> result = Collections.emptyList();
 
-	public def void execute() ;
-	
+	def void execute() ;
+
 	protected def void addToResult(Object o) {
-		result = Optional.of(o);
+		result = Collections.singletonList(o)
 	}
 
-	public def Optional<Object> getResult() {
+	/**
+	 * Get the single result of an executed step command.
+	 * Possible values are:
+	 * - an empty list, if the step command was 'void' and thus did not return a value,
+	 * - a singleton list with the (possibly null) returned value, if the step command was not 'void'.
+	 */
+	def List<Object> getResult() {
 		return result;
 	}
 


### PR DESCRIPTION
The PR https://github.com/diverse-project/k3/pull/87 didn't take into account the case where a method expect to be able to return `null`  (which is different from the case where the method declares `void`)

It has an issue since java optional cannot contain `null`  (using Optional.ofNullable will create an empty optionnal that cannot be distinguished from void return)

This new implementation uses a list.
So an empty list is returned in case of `void`  but a method returning something is still able to set `null` in the list.