### PR TITLE
Fix wizard templates

### DIFF
--- a/k3.eclipse/fr.inria.diverse.k3.ui.templates/templates/miniAspectSample/java/$aspectClassName$.xtend
+++ b/k3.eclipse/fr.inria.diverse.k3.ui.templates/templates/miniAspectSample/java/$aspectClassName$.xtend
@@ -10,11 +10,11 @@ import java.util.ArrayList
 @Aspect(className=java.io.File)
 class $aspectClassName$ {
 	
-	var String contentType = ""
+	public var String contentType = ""
 	
-	var ArrayList<String> contentArrayList = newArrayList("")
+	public var ArrayList<String> contentArrayList = newArrayList("")
 	
-	public def void writeXML(){		
+	def void writeXML(){		
 		var PrintWriter writer = new PrintWriter(_self, "UTF-8");
 		// compute content String by using template
 		val content = '''<xml>

--- a/k3.eclipse/fr.inria.diverse.k3.ui.templates/templates/miniAspectSample/java/$aspectClassName$.xtend
+++ b/k3.eclipse/fr.inria.diverse.k3.ui.templates/templates/miniAspectSample/java/$aspectClassName$.xtend
@@ -18,9 +18,9 @@ class $aspectClassName$ {
 		var PrintWriter writer = new PrintWriter(_self, "UTF-8");
 		// compute content String by using template
 		val content = '''<xml>
-	<«_self.contentType»s>	
-		«FOR contentItem : _self.contentArrayList »<color>«contentItem»</color> «ENDFOR»
-	</«_self.contentType»s>
+	<Â«_self.contentTypeÂ»s>	
+		Â«FOR contentItem : _self.contentArrayList Â»<color>Â«contentItemÂ»</color> Â«ENDFORÂ»
+	</Â«_self.contentTypeÂ»s>
 </xml>'''
 		writer.println(content);
 		writer.close();

--- a/k3.eclipse/fr.inria.diverse.k3.ui.templates/templates/miniEcoreAspectSample/java/$className$.xtend
+++ b/k3.eclipse/fr.inria.diverse.k3.ui.templates/templates/miniEcoreAspectSample/java/$className$.xtend
@@ -12,7 +12,7 @@ import java.util.HashMap
 
 class $className${ 
 
-	public def run(String modelPath, String resultModelPath) {
+	def run(String modelPath, String resultModelPath) {
 		//Load Ecore Model
 		var fact = new EcoreResourceFactoryImpl
 		if (!EPackage.Registry.INSTANCE.containsKey(EcorePackage.eNS_URI)) {

--- a/k3.eclipse/fr.inria.diverse.k3.ui.templates/templates/miniEcoreAspectSample/java/Ecore$aspectClassPostfix$s.xtend
+++ b/k3.eclipse/fr.inria.diverse.k3.ui.templates/templates/miniEcoreAspectSample/java/Ecore$aspectClassPostfix$s.xtend
@@ -34,7 +34,7 @@ class EPackage$aspectClassPostfix$ extends EModelElement$aspectClassPostfix${
 
 @Aspect(className=EClassifier)
 class EClassifier$aspectClassPostfix$ extends EModelElement$aspectClassPostfix${
-	public def void annotate(){
+	def void annotate(){
 		// do nothing in the general case
 	}
 }
@@ -43,13 +43,13 @@ class EClassifier$aspectClassPostfix$ extends EModelElement$aspectClassPostfix${
 class EClass$aspectClassPostfix$ extends EClassifier$aspectClassPostfix${
 	
 	@OverrideAspectMethod
-	public def void annotate(){
+	def void annotate(){
 		// compute the string for the annotation and add it to the class
 		_self.addAnnotation("http://www.eclipse.org/emf/2002/GenModel", "documentation", _self.flat(""))
 	}
 	
 /** Build a String with all superclasses of this class */
-	public def String flat(String tabStr){
+	def String flat(String tabStr){
 		// use a template String
 		// note: in case of strange characters here, make sure to configure your project to use utf8
 val returnedString = '''«tabStr»class «_self.name» : «FOR eSuperClass : _self.ESuperTypes»«eSuperClass.flat( tabStr + "\t")»«ENDFOR»'''
@@ -60,7 +60,7 @@ val returnedString = '''«tabStr»class «_self.name» : «FOR eSuperClass : _se
 
 @Aspect(className=EModelElement)
 class EModelElement$aspectClassPostfix${
-	public def EAnnotation addAnnotation(String source, String detailKey, String detailValue) {
+	def EAnnotation addAnnotation(String source, String detailKey, String detailValue) {
     	// create annotation on the model element only if not already there
 		var EAnnotation theAnnotation =	_self.EAnnotations.findFirst[annot | annot.source.equals(source)]
 		if (theAnnotation == null){

--- a/k3.eclipse/fr.inria.diverse.k3.ui/src/fr/inria/diverse/k3/ui/tools/GenerateGenModelCode.java
+++ b/k3.eclipse/fr.inria.diverse.k3.ui/src/fr/inria/diverse/k3/ui/tools/GenerateGenModelCode.java
@@ -71,7 +71,7 @@ public class GenerateGenModelCode {
 				new org.eclipse.emf.ecore.xmi.impl.EcoreResourceFactoryImpl());
 		ResourceSet resourceSet = new ResourceSetImpl();
 		resourceSet.getURIConverter().getURIMap()
-		.putAll(EcorePlugin.computePlatformURIMap());
+		.putAll(EcorePlugin.computePlatformURIMap(true));
 		URI genModelURI = URI.createFileURI(genModelFile);
 		Resource resource = resourceSet.getResource(genModelURI, true);
 		GenModel eltGenModel = (GenModel)resource.getContents().get(0);
@@ -90,7 +90,7 @@ public class GenerateGenModelCode {
 		IPath ecorePath = new Path(ecorepath);
 		ResourceSet resourceSet = new ResourceSetImpl();
 		resourceSet.getURIConverter().getURIMap()
-				.putAll(EcorePlugin.computePlatformURIMap());
+				.putAll(EcorePlugin.computePlatformURIMap(true));
 		URI ecoreURI = URI.createFileURI(ecorePath.toString());
 		Resource resource = resourceSet.getResource(ecoreURI, true);
 		EPackage ePackage = (EPackage) resource.getContents().get(0);

--- a/k3.eclipse/fr.inria.diverse.k3.ui/src/fr/inria/diverse/k3/ui/tools/K3FileTemplates.java
+++ b/k3.eclipse/fr.inria.diverse.k3.ui/src/fr/inria/diverse/k3/ui/tools/K3FileTemplates.java
@@ -20,13 +20,14 @@ public class K3FileTemplates {
 		StringBuffer buffer= new StringBuffer();
 		buffer.append("Manifest-Version: 1.0" + lineSeparator);
 		buffer.append("Bundle-ManifestVersion: 2" + lineSeparator);
+		buffer.append("Automatic-Module-Name: " + projectName + lineSeparator);
 		buffer.append("Bundle-Name: " + projectName + lineSeparator);
 		buffer.append("Bundle-SymbolicName: " + projectName + "; singleton:=true" + lineSeparator);
 		buffer.append("Bundle-Version: 1.0.0" + lineSeparator);
 		buffer.append("Require-Bundle: ");
-		buffer.append("fr.inria.diverse.k3.al.annotationprocessor.plugin;bundle-version=\"3.0.0\";visibility:=\"reexport\""+ lineSeparator);
+		buffer.append("fr.inria.diverse.k3.al.annotationprocessor.plugin;bundle-version=\"4.0.0\";visibility:=\"reexport\""+ lineSeparator);
 	    buffer.append("Bundle-ClassPath: ." + lineSeparator);
-	    buffer.append("Bundle-RequiredExecutionEnvironment: JavaSE-1.7"+lineSeparator);
+	    buffer.append("Bundle-RequiredExecutionEnvironment: JavaSE-17"+lineSeparator);
 	    
 	    return buffer.toString();
     }

--- a/k3.eclipse/fr.inria.diverse.k3.ui/src/fr/inria/diverse/k3/ui/tools/K3SampleFilesTemplates.xtend
+++ b/k3.eclipse/fr.inria.diverse.k3.ui/src/fr/inria/diverse/k3/ui/tools/K3SampleFilesTemplates.xtend
@@ -1,7 +1,7 @@
 package fr.inria.diverse.k3.ui.tools
 
 class K3SampleFilesTemplates {
-	def public static String getFileTypeK3(String namePackage, String nameClass) {
+	def static String getFileTypeK3(String namePackage, String nameClass) {
 		return '''package  «namePackage» 
 	
 	import org.eclipse.emf.ecore.EPackage
@@ -39,7 +39,7 @@ class K3SampleFilesTemplates {
 '''
 	}
 	
-	def public static String get_MiniAspectSample_SampleMain_xtend(String namePackage) {
+	def static String get_MiniAspectSample_SampleMain_xtend(String namePackage) {
 		return '''package  «namePackage»
 
 import java.io.File
@@ -67,7 +67,7 @@ class SampleMain{
 '''
 	}
 	
-	def public static String get_MiniAspectSample_SampleXMLFileAspect_xtend(String namePackage) {
+	def static String get_MiniAspectSample_SampleXMLFileAspect_xtend(String namePackage) {
 		return '''package  «namePackage»
 
 import fr.inria.diverse.k3.al.annotationprocessor.Aspect
@@ -101,7 +101,7 @@ class SampleXMLFileAspect {
 	}
 
 	
-	def public static String get_MiniAspectSample_SampleEcoreMain_xtend(String namePackage) {
+	def static String get_MiniAspectSample_SampleEcoreMain_xtend(String namePackage) {
 		return '''package  «namePackage»
 
 import org.eclipse.emf.ecore.EPackage
@@ -149,7 +149,7 @@ class SampleEcoreMain{
 '''
 	}
 	
-	def public static String get_MiniAspectSample_SampleAnnotateEcoreAspect_xtend(String namePackage) {
+	def static String get_MiniAspectSample_SampleAnnotateEcoreAspect_xtend(String namePackage) {
 		return '''package  «namePackage»
 
 import fr.inria.diverse.k3.al.annotationprocessor.Aspect
@@ -229,7 +229,7 @@ class EModelElementAspect{
 '''
 	}
 	
-	def public static String buildProperties () {
+	def static String buildProperties () {
 		return '''source.. = src/,\
            xtend-gen/
 output.. = bin/
@@ -240,7 +240,7 @@ bin.includes = plugin.xml,\
 	}
 
 	
-	def public static String getK3SLEStub(String pkgName, String ecoreUri, String mmName) {
+	def static String getK3SLEStub(String pkgName, String ecoreUri, String mmName) {
 		return '''package «pkgName»
 		
 metamodel «mmName» {
@@ -255,7 +255,7 @@ transformation main() {
 '''
 	}
 	
-	def public static String pomXmlMetamodel(String nameProject, String groupID, String artifactID, String version) {
+	def static String pomXmlMetamodel(String nameProject, String groupID, String artifactID, String version) {
 		return '''<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>«groupID»</groupId>
@@ -296,7 +296,7 @@ transformation main() {
 	}
 	
 	
-	def public static String pomXmlK3Ecore(String nameProject, String groupID, String artifactID, String version, String eGroupID, String eArtifactID, String eVersion) {
+	def static String pomXmlK3Ecore(String nameProject, String groupID, String artifactID, String version, String eGroupID, String eArtifactID, String eVersion) {
 		return '''<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -356,7 +356,7 @@ transformation main() {
 </project>'''
 	}
 	
-	def	public static String pomXmlK3(String nameProject, String groupID, String artifactID, String version) {
+	def	static String pomXmlK3(String nameProject, String groupID, String artifactID, String version) {
 		return '''<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -438,7 +438,7 @@ transformation main() {
 </project>'''
 	}
 	
-	def	public static String eclipseResourcePrefs() {
+	def	static String eclipseResourcePrefs() {
 		return '''eclipse.preferences.version=1
 encoding/<project>=UTF-8'''
 	}

--- a/k3.eclipse/fr.inria.diverse.k3.ui/src/fr/inria/diverse/k3/ui/wizards/NewK3ProjectWizard.java
+++ b/k3.eclipse/fr.inria.diverse.k3.ui/src/fr/inria/diverse/k3/ui/wizards/NewK3ProjectWizard.java
@@ -167,8 +167,10 @@ public class NewK3ProjectWizard extends AbstractNewProjectWizardWithTemplates im
 			}
 			createSettingsResourcePrefs(project, monitor);
 
-			IFolderUtils.createFolder(sourceFolderName + getContextNamePackage().replaceAll("\\.", "/"), project,
-					monitor);
+			String folderName = sourceFolderName + getContextNamePackage().replaceAll("\\.", "/");
+			if (!project.getFolder(folderName).exists()) {
+				IFolderUtils.createFolder(folderName, project, monitor);
+			}
 			/*
 			 * if(context.ecoreIFile != null){ createProjectWithEcore(monitor,
 			 * sourceFolderName); } else { if(context.useEMF){

--- a/k3.eclipse/fr.inria.diverse.k3.ui/src/fr/inria/diverse/k3/ui/wizards/NewK3ProjectWizard.java
+++ b/k3.eclipse/fr.inria.diverse.k3.ui/src/fr/inria/diverse/k3/ui/wizards/NewK3ProjectWizard.java
@@ -49,77 +49,73 @@ import fr.inria.diverse.k3.ui.wizards.pages.NewK3ProjectWizardPage;
 
 public class NewK3ProjectWizard extends AbstractNewProjectWizardWithTemplates implements INewWizard {
 
+	protected NewK3ProjectWizardFields context;
 
-	
-	protected NewK3ProjectWizardFields 		context;
-	
-	protected NewK3ProjectWizardPage 		projectPage;
-	//WizardPageCustomNewProjectK3Plugin 	projectPageCustom	 = new WizardPageCustomNewProjectK3Plugin(this.context);
-	
-	
+	protected NewK3ProjectWizardPage projectPage;
+	// WizardPageCustomNewProjectK3Plugin projectPageCustom = new
+	// WizardPageCustomNewProjectK3Plugin(this.context);
+
 	public NewK3ProjectWizard() {
 		context = new NewK3ProjectWizardFields();
 	}
-	
+
 	@Override
 	public void addPages() {
-		projectPage			 = new NewK3ProjectWizardPage(this.context);
-		
-		addPage(projectPage);			
+		projectPage = new NewK3ProjectWizardPage(this.context);
+
+		addPage(projectPage);
 		addPage(getTemplateListSelectionPage(context));
-		
-		
+
 	}
-	
+
 	@Override
 	public void init(IWorkbench workbench, IStructuredSelection selection) {
 		// TODO Auto-generated method stub
-		
+
 	}
-	
+
 	@Override
-	public boolean performFinish() {	
+	public boolean performFinish() {
 		try {
-			IWorkspace workspace = ResourcesPlugin.getWorkspace(); 
+			IWorkspace workspace = ResourcesPlugin.getWorkspace();
 			final IProjectDescription description = workspace.newProjectDescription(this.context.projectName);
 			if (!this.context.projectLocation.equals(workspace.getRoot().getLocation().toOSString()))
 				description.setLocation(new Path(this.context.projectLocation));
-			
+
 			final IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(this.context.projectName);
 			IWorkspaceRunnable operation = new IWorkspaceRunnable() {
 				public void run(IProgressMonitor monitor) throws CoreException {
 					project.create(description, monitor);
 					project.open(monitor);
 					addKermetaNatureToProject(project);
-					
+
 					configureProject(project, monitor);
-					
-					
+
 					// launch the template
-					
+
 					IProjectContentWizard contentWizard = templateSelectionPage.getSelectedWizard();
 					try {
-						getContainer().run(false, true, new ProjectTemplateApplicationOperation(context, project, contentWizard));
+						getContainer().run(false, true,
+								new ProjectTemplateApplicationOperation(context, project, contentWizard));
 					} catch (InvocationTargetException e) {
 						Activator.logErrorMessage(e.getMessage(), e);
 					} catch (InterruptedException e) {
 						Activator.logErrorMessage(e.getMessage(), e);
 					}
-					
-					//setClassPath(project, monitor);
+
+					// setClassPath(project, monitor);
 					project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
 				}
 			};
 			ResourcesPlugin.getWorkspace().run(operation, null);
-			
+
 		} catch (Exception exception) {
 			Activator.logErrorMessage(exception.getMessage(), exception);
 			return false;
 		}
 		return true;
 	}
-	
-	
+
 	@Override
 	public boolean isHelpAvailable() {
 		return true;
@@ -128,29 +124,31 @@ public class NewK3ProjectWizard extends AbstractNewProjectWizardWithTemplates im
 	public void addKermetaNatureToProject(IProject project) {
 		IProjectDescription description;
 		try {
-			
-			description = project.getDescription();	
-			if (!description.hasNature("fr.inria.diverse.k3.ui.k3Nature")){
+
+			description = project.getDescription();
+			if (!description.hasNature("fr.inria.diverse.k3.ui.k3Nature")) {
 				addNature(description, "fr.inria.diverse.k3.ui.k3Nature");
 			}
-			if (!description.hasNature("org.eclipse.jdt.core.javanature")){
+			if (!description.hasNature("org.eclipse.jdt.core.javanature")) {
 				addNature(description, "org.eclipse.jdt.core.javanature");
 			}
-			if(!description.hasNature("org.eclipse.xtext.ui.shared.xtextNature")){
-				addNature(description, "org.eclipse.xtext.ui.shared.xtextNature");				
+			if (!description.hasNature("org.eclipse.xtext.ui.shared.xtextNature")) {
+				addNature(description, "org.eclipse.xtext.ui.shared.xtextNature");
 			}
-			if((this.context.kindsOfProject == NewK3ProjectWizardFields.KindsOfProject.PLUGIN) && (!description.hasNature("org.eclipse.pde.PluginNature"))){
-				addNature(description, "org.eclipse.pde.PluginNature");				
+			if ((this.context.kindsOfProject == NewK3ProjectWizardFields.KindsOfProject.PLUGIN)
+					&& (!description.hasNature("org.eclipse.pde.PluginNature"))) {
+				addNature(description, "org.eclipse.pde.PluginNature");
 			}
-			if((this.context.kindsOfProject == NewK3ProjectWizardFields.KindsOfProject.MAVEN) && (!description.hasNature("org.eclipse.m2e.core.maven2Nature"))){
-				addNature(description, "org.eclipse.m2e.core.maven2Nature");			
+			if ((this.context.kindsOfProject == NewK3ProjectWizardFields.KindsOfProject.MAVEN)
+					&& (!description.hasNature("org.eclipse.m2e.core.maven2Nature"))) {
+				addNature(description, "org.eclipse.m2e.core.maven2Nature");
 			}
 			project.setDescription(description, null);
 		} catch (CoreException e) {
 			Activator.logErrorMessage(e.getMessage(), e);
 		}
 	}
-	
+
 	public void configureProject(IProject project, IProgressMonitor monitor) {
 		try {
 			ManageClasspath classpath;
@@ -160,49 +158,44 @@ public class NewK3ProjectWizard extends AbstractNewProjectWizardWithTemplates im
 			addNature(description, "org.eclipse.jdt.core.javanature");
 			addNature(description, "org.eclipse.xtext.ui.shared.xtextNature");
 			String sourceFolderName;
-			switch(this.context.kindsOfProject){
+			switch (this.context.kindsOfProject) {
 			case MAVEN:
-				sourceFolderName= "src/main/java/";
+				sourceFolderName = "src/main/java/";
 				break;
 			default:
-				sourceFolderName= "src/";
+				sourceFolderName = "src/";
 			}
 			createSettingsResourcePrefs(project, monitor);
 
-			IFolderUtils.createFolder(sourceFolderName + getContextNamePackage().replaceAll("\\.", "/"), project, monitor);
-/*			if(context.ecoreIFile != null){
-				createProjectWithEcore(monitor, sourceFolderName);
-			} else {
-				if(context.useEMF){
-					createMiniEcoreAspectSampleXtend(project, monitor, sourceFolderName);
-				}
-				else{
-					createMiniAspectSampleXtend(project, monitor, sourceFolderName);
-				}
-			}
-*/			
-			switch (this.context.kindsOfProject)
-			{
-			case STANDALONE :
-				IFileUtils.unZip(project, new ProjectDescriptor("fr.inria.diverse.k3.ui","zips/k3.zip"));
-				IFileUtils.unZip(project, new ProjectDescriptor("fr.inria.diverse.k3.ui","zips/xtend.zip"));
-				if(context.useEMF)
-					IFileUtils.unZip(project, new ProjectDescriptor("fr.inria.diverse.k3.ui","zips/emf.zip"));				
+			IFolderUtils.createFolder(sourceFolderName + getContextNamePackage().replaceAll("\\.", "/"), project,
+					monitor);
+			/*
+			 * if(context.ecoreIFile != null){ createProjectWithEcore(monitor,
+			 * sourceFolderName); } else { if(context.useEMF){
+			 * createMiniEcoreAspectSampleXtend(project, monitor, sourceFolderName); } else{
+			 * createMiniAspectSampleXtend(project, monitor, sourceFolderName); } }
+			 */
+			switch (this.context.kindsOfProject) {
+			case STANDALONE:
+				IFileUtils.unZip(project, new ProjectDescriptor("fr.inria.diverse.k3.ui", "zips/k3.zip"));
+				IFileUtils.unZip(project, new ProjectDescriptor("fr.inria.diverse.k3.ui", "zips/xtend.zip"));
+				if (context.useEMF)
+					IFileUtils.unZip(project, new ProjectDescriptor("fr.inria.diverse.k3.ui", "zips/emf.zip"));
 				classpath = new ManageClasspathStandAlone("lib");
 				classpath.setClasspath(project, monitor);
 				break;
-			case PLUGIN :
+			case PLUGIN:
 				classpath = new ManageClasspathPlugin(this.context.useSLE);
 				addNature(description, "org.eclipse.pde.PluginNature");
 				configurePluginProject(project, monitor);
 				classpath.setClasspath(project, monitor);
 
 				if (context.useSLE) {
-					classpath.setClasspath(project,  monitor);
+					classpath.setClasspath(project, monitor);
 				}
 
 				break;
-			case MAVEN :
+			case MAVEN:
 				classpath = new ManageClasspathMaven();
 				addNature(description, "org.eclipse.m2e.core.maven2Nature");
 				createMavenFile(project, monitor, false);
@@ -214,8 +207,8 @@ public class NewK3ProjectWizard extends AbstractNewProjectWizardWithTemplates im
 			Activator.logErrorMessage(e.getMessage(), e);
 		}
 	}
-	
-	private void configurePluginProject (IProject project, IProgressMonitor monitor) {
+
+	private void configurePluginProject(IProject project, IProgressMonitor monitor) {
 		try {
 			createManifestFile(project, monitor);
 			ManifestChanger manifestChanger = new ManifestChanger(project.getFile("META-INF/MANIFEST.MF"));
@@ -223,237 +216,244 @@ public class NewK3ProjectWizard extends AbstractNewProjectWizardWithTemplates im
 			manifestChanger.addPluginDependency("org.eclipse.xtend.lib", "2.6.0", false, true);
 			manifestChanger.addPluginDependency("org.eclipse.xtext.xbase.lib", "2.6.0", false, true);
 			manifestChanger.addPluginDependency("com.google.guava", "0.0.0", false, true);
-			if(context.useEMF){
+			if (context.useEMF) {
 				manifestChanger.addPluginDependency("org.eclipse.emf.ecore.xmi", "2.8.0", true, true);
 				manifestChanger.addPluginDependency("org.eclipse.emf.ecore", "2.8.0", true, true);
 				manifestChanger.addPluginDependency("org.eclipse.emf.common", "2.8.0", true, true);
-				if(context.ecoreIFile != null ){
-					manifestChanger.addPluginDependency(context.ecoreIFile.getProject().getName(),"0.0.0", true, true);
+				if (context.ecoreIFile != null) {
+					manifestChanger.addPluginDependency(context.ecoreIFile.getProject().getName(), "0.0.0", true, true);
 				}
-				if(context.useSLE) {
+				if (context.useSLE) {
 					manifestChanger.addPluginDependency("fr.inria.diverse.k3.sle.lib", "3.0.0", true, true);
 				}
 			}
 			manifestChanger.commit();
 			createPlugInFile(project, monitor);
-			createBuildProperties(project, monitor);			
+			createBuildProperties(project, monitor);
 		} catch (Exception e) {
 			Activator.logErrorMessage(e.getMessage(), e);
 		}
 	}
-	
+
 	public static void addNature(IProjectDescription description, String nature) {
 		String[] natures = description.getNatureIds();
 		String[] newNatures = new String[natures.length + 1];
 		System.arraycopy(natures, 0, newNatures, 0, natures.length);
 		newNatures[natures.length] = nature;
 		description.setNatureIds(newNatures);
-	}	
-	
-    private void createManifestFile(IProject project, IProgressMonitor monitor) throws Exception {	
-	    IFolder metaInf = project.getFolder("META-INF");
-	    metaInf.create(false, true, monitor);
-	    
-	    String path = "META-INF/MANIFEST.MF";
+	}
+
+	private void createManifestFile(IProject project, IProgressMonitor monitor) throws Exception {
+		IFolder metaInf = project.getFolder("META-INF");
+		metaInf.create(false, true, monitor);
+
+		String path = "META-INF/MANIFEST.MF";
 		IContainer currentContainer = project;
 		IFile file = currentContainer.getFile(new Path(path));
-		
-		String contents = K3FileTemplates.manifestMFPlugin(this.context.projectName, new ArrayList<String>(), new ArrayList<String>());
-		IFileUtils.writeInFile(file, contents, monitor);    
-    }
-	
-    private void createBuildProperties(IProject project, IProgressMonitor monitor) throws Exception {	    
-	    String path = "build.properties";
+
+		String contents = K3FileTemplates.manifestMFPlugin(this.context.projectName, new ArrayList<String>(),
+				new ArrayList<String>());
+		IFileUtils.writeInFile(file, contents, monitor);
+	}
+
+	private void createBuildProperties(IProject project, IProgressMonitor monitor) throws Exception {
+		String path = "build.properties";
 		IContainer currentContainer = project;
 		IFile file = currentContainer.getFile(new Path(path));
-		
+
 		String contents = K3SampleFilesTemplates.buildProperties();
-		IFileUtils.writeInFile(file, contents, monitor);   
-    }
-    
-    private void createSettingsResourcePrefs(IProject project, IProgressMonitor monitor) throws Exception {	    
-    	IFolder settings = project.getFolder(".settings");
-    	settings.create(false, true, monitor);
-	    
-	    String path = ".settings/org.eclipse.core.resources.prefs";
+		IFileUtils.writeInFile(file, contents, monitor);
+	}
+
+	private void createSettingsResourcePrefs(IProject project, IProgressMonitor monitor) throws Exception {
+		IFolder settings = project.getFolder(".settings");
+		if (!settings.exists()) {
+			settings.create(false, true, monitor);
+		}
+
+		String path = ".settings/org.eclipse.core.resources.prefs";
 		IContainer currentContainer = project;
 		IFile file = currentContainer.getFile(new Path(path));
-		
-		String contents = K3SampleFilesTemplates.eclipseResourcePrefs();
-		IFileUtils.writeInFile(file, contents, monitor);   
-    }
-    
-	private void createPlugInFile(IProject project,IProgressMonitor monitor) throws Exception {
+		if (!file.exists()) {
+			String contents = K3SampleFilesTemplates.eclipseResourcePrefs();
+			IFileUtils.writeInFile(file, contents, monitor);
+		}
+	}
+
+	private void createPlugInFile(IProject project, IProgressMonitor monitor) throws Exception {
 		String path = "/plugin.xml";
 		IContainer currentContainer = project;
 		IFile file = currentContainer.getFile(new Path(path));
-		
+
 		String contents = K3FileTemplates.pluginbasisXML();
 		IFileUtils.writeInFile(file, contents, monitor);
 	}
-	
-	private void createMavenFile(IProject project,IProgressMonitor monitor, Boolean bEcoreProject) throws Exception {
+
+	private void createMavenFile(IProject project, IProgressMonitor monitor, Boolean bEcoreProject) throws Exception {
 		String path = "/pom.xml";
 		IContainer currentContainer = project;
 		IFile file = currentContainer.getFile(new Path(path));
 		String contents = "";
-		if(!bEcoreProject) {
-			if(this.context.ecoreIFile != null) {
-				contents = K3SampleFilesTemplates.pomXmlK3Ecore(this.context.projectName, "GroupID", "ArtifactID", "0.0.1-SNAPSHOT", this.context.ecoreIFile.getName() + ".metamodel", this.context.ecoreIFile.getName() + ".metamodel", "0.0.1-SNAPSHOT");
-			}else {
-				contents = K3SampleFilesTemplates.pomXmlK3(this.context.projectName, "GroupID", "ArtifactID", "0.0.1-SNAPSHOT");
+		if (!bEcoreProject) {
+			if (this.context.ecoreIFile != null) {
+				contents = K3SampleFilesTemplates.pomXmlK3Ecore(this.context.projectName, "GroupID", "ArtifactID",
+						"0.0.1-SNAPSHOT", this.context.ecoreIFile.getName() + ".metamodel",
+						this.context.ecoreIFile.getName() + ".metamodel", "0.0.1-SNAPSHOT");
+			} else {
+				contents = K3SampleFilesTemplates.pomXmlK3(this.context.projectName, "GroupID", "ArtifactID",
+						"0.0.1-SNAPSHOT");
 			}
 		} else {
-			contents = K3SampleFilesTemplates.pomXmlMetamodel(this.context.ecoreIFile.getName() + ".metamodel", this.context.ecoreIFile.getName() + ".metamodel", this.context.ecoreIFile.getName() + ".metamodel", "0.0.1-SNAPSHOT");
+			contents = K3SampleFilesTemplates.pomXmlMetamodel(this.context.ecoreIFile.getName() + ".metamodel",
+					this.context.ecoreIFile.getName() + ".metamodel", this.context.ecoreIFile.getName() + ".metamodel",
+					"0.0.1-SNAPSHOT");
 		}
 		IFileUtils.writeInFile(file, contents, monitor);
 	}
-		
-/*	private void createDefaultKmt(IProject project,IProgressMonitor monitor, String sourceFolderName) throws CoreException{
-		String path = sourceFolderName + this.context.namePackage + "/HelloEcore.xtend";
-		IContainer currentContainer = project;
-		IFile file = currentContainer.getFile(new Path(path));
-		
-		String contents = K3SampleFilesTemplates.getFileTypeK3(this.context.namePackage, "HelloEcore");
-		
-		FileUtils.writeInFile(file, contents, monitor);		
-	}
-	
-	private void createMiniEcoreAspectSampleXtend(IProject project,IProgressMonitor monitor, String sourceFolderName) throws CoreException{
-		IContainer currentContainer = project;
-		IFile file = currentContainer.getFile(new Path(sourceFolderName + this.context.namePackage + "/SampleEcoreMain.xtend"));
-		
-		String contents = K3SampleFilesTemplates.get_MiniAspectSample_SampleEcoreMain_xtend(this.context.namePackage);		
-		FileUtils.writeInFile(file, contents, monitor);		
-		
-		// second file of the sample
-		file = currentContainer.getFile(new Path(sourceFolderName + this.context.namePackage + "/SampleEcoreAspect.xtend"));
-		
-		contents = K3SampleFilesTemplates.get_MiniAspectSample_SampleAnnotateEcoreAspect_xtend(this.context.namePackage);		
-		FileUtils.writeInFile(file, contents, monitor);
-		
-	}
-	
-	private void createMiniAspectSampleXtend(IProject project,IProgressMonitor monitor, String sourceFolderName) throws CoreException{
-		IContainer currentContainer = project;
-		IFile file = currentContainer.getFile(new Path(sourceFolderName + this.context.namePackage + "/SampleMain.xtend"));
-		
-		String contents = K3SampleFilesTemplates.get_MiniAspectSample_SampleMain_xtend(this.context.namePackage);		
-		FileUtils.writeInFile(file, contents, monitor);		
-		
-		// second file of the sample
-		file = currentContainer.getFile(new Path(sourceFolderName + this.context.namePackage + "/SampleXMLFileAspect.xtend"));
-		
-		contents = K3SampleFilesTemplates.get_MiniAspectSample_SampleXMLFileAspect_xtend(this.context.namePackage);		
-		FileUtils.writeInFile(file, contents, monitor);
-		
-	}
 
-	private void createK3SLEStub(IProject project,IProgressMonitor monitor, String sourceFolderName) throws CoreException{
-		String mmName = this.context.ecoreIFile.getName().substring(0, this.context.ecoreIFile.getName().indexOf("."));
-		String ecorePlatformPath = this.context.ecoreIFile.toString().replaceFirst("L", "platform:/resource");
-		String path = sourceFolderName + this.context.namePackage + "/" + mmName + ".k3sle";
-		IContainer currentContainer = project;
-		IFile file = currentContainer.getFile(new Path(path));
-
-		String contents = K3SampleFilesTemplates.getK3SLEStub(this.context.namePackage, ecorePlatformPath, mmName);
-
-		FileUtils.writeInFile(file, contents, monitor);
-	}
-*/	
+	/*
+	 * private void createDefaultKmt(IProject project,IProgressMonitor monitor,
+	 * String sourceFolderName) throws CoreException{ String path = sourceFolderName
+	 * + this.context.namePackage + "/HelloEcore.xtend"; IContainer currentContainer
+	 * = project; IFile file = currentContainer.getFile(new Path(path));
+	 * 
+	 * String contents =
+	 * K3SampleFilesTemplates.getFileTypeK3(this.context.namePackage, "HelloEcore");
+	 * 
+	 * FileUtils.writeInFile(file, contents, monitor); }
+	 * 
+	 * private void createMiniEcoreAspectSampleXtend(IProject
+	 * project,IProgressMonitor monitor, String sourceFolderName) throws
+	 * CoreException{ IContainer currentContainer = project; IFile file =
+	 * currentContainer.getFile(new Path(sourceFolderName + this.context.namePackage
+	 * + "/SampleEcoreMain.xtend"));
+	 * 
+	 * String contents =
+	 * K3SampleFilesTemplates.get_MiniAspectSample_SampleEcoreMain_xtend(this.
+	 * context.namePackage); FileUtils.writeInFile(file, contents, monitor);
+	 * 
+	 * // second file of the sample file = currentContainer.getFile(new
+	 * Path(sourceFolderName + this.context.namePackage +
+	 * "/SampleEcoreAspect.xtend"));
+	 * 
+	 * contents =
+	 * K3SampleFilesTemplates.get_MiniAspectSample_SampleAnnotateEcoreAspect_xtend(
+	 * this.context.namePackage); FileUtils.writeInFile(file, contents, monitor);
+	 * 
+	 * }
+	 * 
+	 * private void createMiniAspectSampleXtend(IProject project,IProgressMonitor
+	 * monitor, String sourceFolderName) throws CoreException{ IContainer
+	 * currentContainer = project; IFile file = currentContainer.getFile(new
+	 * Path(sourceFolderName + this.context.namePackage + "/SampleMain.xtend"));
+	 * 
+	 * String contents =
+	 * K3SampleFilesTemplates.get_MiniAspectSample_SampleMain_xtend(this.context.
+	 * namePackage); FileUtils.writeInFile(file, contents, monitor);
+	 * 
+	 * // second file of the sample file = currentContainer.getFile(new
+	 * Path(sourceFolderName + this.context.namePackage +
+	 * "/SampleXMLFileAspect.xtend"));
+	 * 
+	 * contents =
+	 * K3SampleFilesTemplates.get_MiniAspectSample_SampleXMLFileAspect_xtend(this.
+	 * context.namePackage); FileUtils.writeInFile(file, contents, monitor);
+	 * 
+	 * }
+	 * 
+	 * private void createK3SLEStub(IProject project,IProgressMonitor monitor,
+	 * String sourceFolderName) throws CoreException{ String mmName =
+	 * this.context.ecoreIFile.getName().substring(0,
+	 * this.context.ecoreIFile.getName().indexOf(".")); String ecorePlatformPath =
+	 * this.context.ecoreIFile.toString().replaceFirst("L", "platform:/resource");
+	 * String path = sourceFolderName + this.context.namePackage + "/" + mmName +
+	 * ".k3sle"; IContainer currentContainer = project; IFile file =
+	 * currentContainer.getFile(new Path(path));
+	 * 
+	 * String contents =
+	 * K3SampleFilesTemplates.getK3SLEStub(this.context.namePackage,
+	 * ecorePlatformPath, mmName);
+	 * 
+	 * FileUtils.writeInFile(file, contents, monitor); }
+	 */
 	public NewK3ProjectWizardFields getContext() {
 		return context;
 	}
-	
-/*	public boolean createProjectWithEcore(IProgressMonitor monitor, String sourceFolderName) {
-		boolean returnVal = true;
 
-		updateBasePackageFromGenModel(this.context);
-
-				
-		if (this.context.indexTransfomation != 0) {
-			k3.language.aspectgenerator.AspectGenerator.aspectGenerate (
-					context.basePackage,
-					"File:///"+this.context.locationProject,
-					this.context.nameProject,
-					this.context.operationName,
-					"File:///"+this.context.ecoreIFile.getLocation().toOSString(), 
-					this.context.listNewClass, 
-					this.context.operationParams);			
-		}
-
-		if (this.context.useSLE){
-			try {
-				final IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(this.context.nameProject);
-				IFolderUtils.createFolder(sourceFolderName + getContextNamePackage(), project, monitor);
-				createK3SLEStub(project, monitor, sourceFolderName);
-			} catch (CoreException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}
-		}
-
-		return returnVal;
-	}
-*/
+	/*
+	 * public boolean createProjectWithEcore(IProgressMonitor monitor, String
+	 * sourceFolderName) { boolean returnVal = true;
+	 * 
+	 * updateBasePackageFromGenModel(this.context);
+	 * 
+	 * 
+	 * if (this.context.indexTransfomation != 0) {
+	 * k3.language.aspectgenerator.AspectGenerator.aspectGenerate (
+	 * context.basePackage, "File:///"+this.context.locationProject,
+	 * this.context.nameProject, this.context.operationName,
+	 * "File:///"+this.context.ecoreIFile.getLocation().toOSString(),
+	 * this.context.listNewClass, this.context.operationParams); }
+	 * 
+	 * if (this.context.useSLE){ try { final IProject project =
+	 * ResourcesPlugin.getWorkspace().getRoot().getProject(this.context.nameProject)
+	 * ; IFolderUtils.createFolder(sourceFolderName + getContextNamePackage(),
+	 * project, monitor); createK3SLEStub(project, monitor, sourceFolderName); }
+	 * catch (CoreException e) { // TODO Auto-generated catch block
+	 * e.printStackTrace(); } }
+	 * 
+	 * return returnVal; }
+	 */
 	public void addNatureToProject(IProject project, Boolean tabNature[]) {
 		IProjectDescription description;
 		try {
-			
+
 			description = project.getDescription();
-			if (!tabNature[0] && !description.hasNature("fr.inria.diverse.k3.ui.k3Nature")){
+			if (!tabNature[0] && !description.hasNature("fr.inria.diverse.k3.ui.k3Nature")) {
 				addNature(description, "fr.inria.diverse.k3.ui.k3Nature");
 			}
-			if (!tabNature[1] && !description.hasNature("org.eclipse.jdt.core.javanature")){
+			if (!tabNature[1] && !description.hasNature("org.eclipse.jdt.core.javanature")) {
 				addNature(description, "org.eclipse.jdt.core.javanature");
 			}
-			if(!tabNature[2] && !description.hasNature("org.eclipse.xtext.ui.shared.xtextNature")){
-				addNature(description, "org.eclipse.xtext.ui.shared.xtextNature");				
+			if (!tabNature[2] && !description.hasNature("org.eclipse.xtext.ui.shared.xtextNature")) {
+				addNature(description, "org.eclipse.xtext.ui.shared.xtextNature");
 			}
-			if(!tabNature[3] && (!description.hasNature("org.eclipse.pde.PluginNature"))){
-				addNature(description, "org.eclipse.pde.PluginNature");				
+			if (!tabNature[3] && (!description.hasNature("org.eclipse.pde.PluginNature"))) {
+				addNature(description, "org.eclipse.pde.PluginNature");
 			}
-			if(!tabNature[4] && (!description.hasNature("org.eclipse.m2e.core.maven2Nature"))){
-				addNature(description, "org.eclipse.m2e.core.maven2Nature");			
+			if (!tabNature[4] && (!description.hasNature("org.eclipse.m2e.core.maven2Nature"))) {
+				addNature(description, "org.eclipse.m2e.core.maven2Nature");
 			}
 			project.setDescription(description, null);
 		} catch (CoreException e) {
 			Activator.logErrorMessage(e.getMessage(), e);
 		}
 	}
-	
-	
+
 	private String getContextNamePackage() {
-		if(this.context.namePackage == null || this.context.namePackage.isEmpty()){
+		if (this.context.namePackage == null || this.context.namePackage.isEmpty()) {
 			// create a name from the project name
 			return JavaNameHelper.getFormattedPackageName(context.projectName);
-		}
-		else {
+		} else {
 			return this.context.namePackage;
 		}
 	}
 
-	
-	
 	public NewK3ProjectWizardPage getPageProject() {
 		return this.projectPage;
 	}
-	
-/*	public void updateBasePackageFromGenModel(NewK3ProjectWizardFields context) {
-		 GenerateGenModelCode genmodel = new GenerateGenModelCode();
-		 String basePackage;
-		if(genmodel.existGenModel(context)) {
-			basePackage = genmodel.getBasePackage(context.genModelFile);
-			if (basePackage != null)
-				context.basePackage = new ToolsString().generateListPackage(basePackage, (byte)46);
-		}
-	}*/
+
+	/*
+	 * public void updateBasePackageFromGenModel(NewK3ProjectWizardFields context) {
+	 * GenerateGenModelCode genmodel = new GenerateGenModelCode(); String
+	 * basePackage; if(genmodel.existGenModel(context)) { basePackage =
+	 * genmodel.getBasePackage(context.genModelFile); if (basePackage != null)
+	 * context.basePackage = new ToolsString().generateListPackage(basePackage,
+	 * (byte)46); } }
+	 */
 
 	@Override
-	public String getTargetPluginId() {		
+	public String getTargetPluginId() {
 		return Activator.PLUGIN_ID;
 	}
-	
-	
-	
+
 }

--- a/k3.eclipse/fr.inria.diverse.k3.ui/src/fr/inria/diverse/k3/ui/wizards/pages/NewK3ProjectCustomWizardPage.java
+++ b/k3.eclipse/fr.inria.diverse.k3.ui/src/fr/inria/diverse/k3/ui/wizards/pages/NewK3ProjectCustomWizardPage.java
@@ -10,18 +10,7 @@
  *******************************************************************************/
 package fr.inria.diverse.k3.ui.wizards.pages;
 
-import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.wizard.WizardPage;
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.ModifyEvent;
-import org.eclipse.swt.events.ModifyListener;
-import org.eclipse.swt.events.SelectionAdapter;
-import org.eclipse.swt.events.SelectionEvent;
-import org.eclipse.swt.layout.FillLayout;
-import org.eclipse.swt.layout.GridData;
-import org.eclipse.swt.layout.GridLayout;
-import org.eclipse.swt.layout.RowData;
-import org.eclipse.swt.layout.RowLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;

--- a/k3.eclipse/fr.inria.diverse.k3.ui/src/fr/inria/diverse/k3/ui/wizards/pages/NewK3ProjectWizardFields.java
+++ b/k3.eclipse/fr.inria.diverse.k3.ui/src/fr/inria/diverse/k3/ui/wizards/pages/NewK3ProjectWizardFields.java
@@ -10,12 +10,8 @@
  *******************************************************************************/
 package fr.inria.diverse.k3.ui.wizards.pages;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.ResourcesPlugin;
-
 import org.eclipse.gemoc.commons.eclipse.pde.wizards.pages.pde.ui.BaseProjectWizardFields;
 
 public class NewK3ProjectWizardFields extends BaseProjectWizardFields {

--- a/k3.eclipse/fr.inria.diverse.k3.ui/src/fr/inria/diverse/k3/ui/xtend/ide/support/K3XtendExecutableExtensionFactory.java
+++ b/k3.eclipse/fr.inria.diverse.k3.ui/src/fr/inria/diverse/k3/ui/xtend/ide/support/K3XtendExecutableExtensionFactory.java
@@ -18,7 +18,6 @@ import org.eclipse.core.runtime.IExecutableExtension;
 import org.eclipse.core.runtime.IExecutableExtensionFactory;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.xtend.ide.XtendExecutableExtensionFactory;
 import org.eclipse.xtend.ide.internal.XtendActivator;
 import org.osgi.framework.Bundle;
 


### PR DESCRIPTION
This PR fixes several bugs that were present in the new Project wizard templates:

- UTF8 encoding,
- failure to finish the process due to existing src folder, due to existing .settings folder
- fix of the public/private visibility of the miniAspectExample


This PR  also improve the code (and the generated code) by removing public/private warnings fro xtend.