### PR TITLE
Fix error in command.getResult()

### DIFF
--- a/k3.eclipse/fr.inria.diverse.k3.al.annotationprocessor.plugin/src/fr/inria/diverse/k3/al/annotationprocessor/Aspect.xtend
+++ b/k3.eclipse/fr.inria.diverse.k3.al.annotationprocessor.plugin/src/fr/inria/diverse/k3/al/annotationprocessor/Aspect.xtend
@@ -498,7 +498,7 @@ if («SELF_VAR_NAME» instanceof «Helper::getAspectedClassName(dt)»){
 				command.execute();
 			}
 			«IF hasReturn»
-				«resultVar» = command.getResult().get();
+				«resultVar» = command.getResult().get(0);
 			«ENDIF»
 		'''
 	}


### PR DESCRIPTION
Fix a small bug in the code handling methods with a return value, where an index `0` was missing to retrieve the value in the resulting list.